### PR TITLE
 replace frequency weights by analytic weights 

### DIFF
--- a/src/histogram.jl
+++ b/src/histogram.jl
@@ -5,8 +5,8 @@
 
 abstract type WeightedHistogramStat{T} <: WeightedOnlineStat{T} end
 split_candidates(o::WeightedHistogramStat) = midpoints(o)
-Statistics.mean(o::WeightedHistogramStat) = mean(midpoints(o), fweights(counts(o)))
-Statistics.var(o::WeightedHistogramStat) = var(midpoints(o), fweights(counts(o)); corrected=true)
+Statistics.mean(o::WeightedHistogramStat) = mean(midpoints(o), aweights(counts(o)))
+Statistics.var(o::WeightedHistogramStat) = var(midpoints(o), aweights(counts(o)); corrected=true)
 Statistics.std(o::WeightedHistogramStat) = sqrt(var(o))
 Statistics.median(o::WeightedHistogramStat) = quantile(o, .5)
 
@@ -65,7 +65,7 @@ end
 function Statistics.quantile(o::WeightedHist, p = [0, .25, .5, .75, 1])
     x, y = midpoints(o), counts(o)
     inds = findall(x -> x != 0, y)
-    quantile(x[inds], fweights(y[inds]), p)
+    quantile(x[inds], aweights(y[inds]), p)
 end
 
 function area(o::WeightedHist)
@@ -162,7 +162,7 @@ end
 function Statistics.quantile(o::WeightedAdaptiveHist, p = [0, .25, .5, .75, 1])
     mids, counts = value(o)
     inds = findall(x->x!=0, counts)  # filter out zero weights
-    quantile(mids[inds], fweights(counts[inds]), p)
+    quantile(mids[inds], aweights(counts[inds]), p)
 end
 
 function weightsum(o::WeightedAdaptiveHist)

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -1,5 +1,5 @@
 abstract type WeightedOnlineStat{T} <: OnlineStat{T} end
-using OnlineStats: fweights
+using OnlineStats: fweights, aweights
 
 meanweight(o::WeightedOnlineStat) = o.W
 weightsum(o::WeightedOnlineStat) = meanweight(o) * nobs(o)


### PR DESCRIPTION
FrequencyWeights from StatsBase only accept integer values. This is only a quick fix, it might be better to allow the user to choose different weight types in the interface functions.