### PR TITLE
Make coverage run.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,4 +20,5 @@ matrix:
     - julia: nightly
 
 after_success:
-  - julia -e 'cd(Pkg.dir("WeightedOnlineStats")); Pkg.add("Coverage"); using Coverage; Codecov.submit(process_folder())'
+  - julia --project=test/coverage -e 'using Pkg; Pkg.instantiate()'
+  - julia --project=test/coverage test/coverage/coverage.jl

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # `WeightedOnlineStats.jl`
 [![Build Status](https://travis-ci.org/gdkrmr/WeightedOnlineStats.jl.svg?branch=master)](https://travis-ci.org/gdkrmr/WeightedOnlineStats.jl)
 [![DOI](https://zenodo.org/badge/156201284.svg)](https://zenodo.org/badge/latestdoi/156201284)
+[![codecov.io](http://codecov.io/github/gdkrmr/WeightedOnlineStats.jl/coverage.svg?branch=master)](http://codecov.io/github/gdkrmr/WeightedOnlineStats.jl?branch=master)
 
 An extension of `OnlineStatsBase.jl` that supports proper statistical weighting
 and arbitrary numerical precision.

--- a/test/coverage/Project.toml
+++ b/test/coverage/Project.toml
@@ -1,0 +1,2 @@
+[deps]
+Coverage = "a2441757-f6aa-5fb2-8edb-039e3f45d037"

--- a/test/coverage/coverage.jl
+++ b/test/coverage/coverage.jl
@@ -1,0 +1,9 @@
+# only push coverage from one bot
+get(ENV, "TRAVIS_OS_NAME", nothing)       == "linux" || exit(0)
+get(ENV, "TRAVIS_JULIA_VERSION", nothing) == "1.3"   || exit(0)
+
+using Coverage
+
+cd(joinpath(@__DIR__, "..", "..")) do
+    Codecov.submit(Codecov.process_folder())
+end


### PR DESCRIPTION
Using the standard project-based setup.

(Currently, this part of the travis script fails silently).