### PR TITLE
Quick fix to use aweights instead of fweights in WeightedHistograms

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ sudo: false
 os:
   - linux
   - osx
+  - windows
 
 julia:
   - 1.0

--- a/src/WeightedOnlineStats.jl
+++ b/src/WeightedOnlineStats.jl
@@ -22,7 +22,7 @@ import Statistics
 import Statistics: mean, var, std, cov, cor, median, quantile
 import LinearAlgebra
 import LinearAlgebra: Hermitian, lmul!, rmul!, Diagonal, diag
-import StatsBase: midpoints
+import StatsBase: midpoints, aweights
 
 include("interface.jl")
 include("sum.jl")

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -1,5 +1,5 @@
 abstract type WeightedOnlineStat{T} <: OnlineStat{T} end
-using OnlineStats: fweights, aweights
+using OnlineStats: fweights
 
 meanweight(o::WeightedOnlineStat) = o.W
 weightsum(o::WeightedOnlineStat) = meanweight(o) * nobs(o)

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -1,5 +1,5 @@
 abstract type WeightedOnlineStat{T} <: OnlineStat{T} end
-using OnlineStats: fweights
+using OnlineStats: fweights, aweights
 
 meanweight(o::WeightedOnlineStat) = o.W
 weightsum(o::WeightedOnlineStat) = meanweight(o) * nobs(o)


### PR DESCRIPTION
This is a quick fix for an error, which results from using fweights in quantile computation:
```
ArgumentError: The values of the vector of `FrequencyWeights` must be numericallyequal to integers. Use `ProbabilityWeights` or `AnalyticWeights` instead.
```
The latest commit should work fine in Travis now.