### PR TITLE
move pca to an extension

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -18,10 +18,17 @@ OnlineStatsBase = "1"
 StatsBase = "0.32.1, 0.33, 0.34"
 julia = "1"
 
+[extensions]
+PcaExt = "MultivariateStats"
+
 [extras]
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
+MultivariateStats = "6f286f6a-111f-5878-ab1e-185364afe411"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "Random", "StatsBase"]
+test = ["Test", "Random", "StatsBase", "MultivariateStats"]
+
+[weakdeps]
+MultivariateStats = "6f286f6a-111f-5878-ab1e-185364afe411"

--- a/ext/PcaExt.jl
+++ b/ext/PcaExt.jl
@@ -1,3 +1,7 @@
+module PcaExt
+
+using WeightedOnlineStats
+
 import StatsBase
 import StatsBase: ZScoreTransform
 export ZScoreTransform
@@ -9,7 +13,7 @@ import MultivariateStats:
     predict
 
 export
-    pca, PCA, pcacov, indim, outdim, projection, principalvar, principalvars,
+    PCA, pcacov, indim, outdim, projection, principalvar, principalvars,
     tprincipalvar, tresidualvar, tvar, principalratio, transform, reconstruct
 
 """
@@ -29,7 +33,7 @@ from a `WeightedCovMatrix`.
     c = fit!(WeightedCovMatrix(), rand(4, 100), rand(100))
     t, p = pca(c)
 """
-function pca(
+function WeightedOnlineStats.pca(
     x::WeightedCovMatrix{T};
     cov_pca::Bool = false,
     maxoutdim::Int = size(x, 1),
@@ -85,3 +89,5 @@ end
 #     return x
 # end
 
+
+end # module

--- a/src/WeightedOnlineStats.jl
+++ b/src/WeightedOnlineStats.jl
@@ -31,6 +31,9 @@ include("var.jl")
 include("covmatrix.jl")
 
 export pca
+"""
+    `pca` creates a PCA object from a `WeightedCovMatrix` object. Requires MultivariateStats to be loaded!
+"""
 function pca end
 if !isdefined(Base, :get_extension)
     include("../ext/PcaExt.jl")

--- a/src/WeightedOnlineStats.jl
+++ b/src/WeightedOnlineStats.jl
@@ -29,7 +29,13 @@ include("sum.jl")
 include("mean.jl")
 include("var.jl")
 include("covmatrix.jl")
-include("pca.jl")
+
+export pca
+function pca end
+if !isdefined(Base, :get_extension)
+    include("../ext/PcaExt.jl")
+end
+
 include("histogram.jl")
 
 end # module WeightedOnlineStats


### PR DESCRIPTION
I have made MultivariateStats an optional dependency. Works on Julia 1.9 and 1.6, so I must have done something right.

What I don't understand yet is if we have to do

```julia
export pca
function pca end
```
In WeightedOnlineStats.jl or if we can keep this entirely contained within the extension.