### PR TITLE
recover from NaNs

### DIFF
--- a/src/mean.jl
+++ b/src/mean.jl
@@ -27,7 +27,12 @@ function OnlineStatsBase._fit!(o::WeightedMean{T}, x, w) where T
 
     o.n += 1
     o.W = smooth(o.W, ww, T(1) / o.n)
-    o.μ = smooth(o.μ, xx, ww / (o.W * o.n))
+
+    if isnan(o.μ)
+        o.μ = smooth(T(0), xx, ww / (o.W * o.n))
+    else
+        o.μ = smooth(o.μ, xx, ww / (o.W * o.n))
+    end
 
     o
 end
@@ -38,6 +43,13 @@ function OnlineStatsBase._merge!(o::WeightedMean{T}, o2::WeightedMean) where T
 
     o.n += o2.n
     o.W = smooth(o.W, o2_W, o2.n / o.n)
+
+    if isnan(o.μ)
+        o.μ = T(0)
+    end
+    if isnan(o2_μ)
+        o2_μ = T(0)
+    end
     o.μ = smooth(o.μ, o2_μ, (o2_W * o2.n) / (o.W * o.n))
 
     o

--- a/test/test_mean.jl
+++ b/test/test_mean.jl
@@ -64,3 +64,62 @@ end
     @test WeightedMean() == WeightedMean(0.0, 0.0, 0)
     @test WeightedMean() == WeightedMean{Float64}(0, 0, 0)
 end
+
+@testset "issue #42" begin
+    # https://github.com/gdkrmr/WeightedOnlineStats.jl/issues/42
+
+    x = ones(3)
+    w = [0.0, 0.5, 1.0]
+
+    m1 = WeightedMean()
+    m2 = WeightedMean()
+
+    # value NaN because the first weight is zero
+    fit!(m1, x, w)
+    # but if we reverse the sequences everything works as expected:
+    fit!(m2, reverse(x), reverse(w))
+    # WeightedMean: ∑wᵢ=1.5 | value=1.0
+    @test m1 == m2
+
+    # zero weight mean later in the sequence should be recoverable
+    x = [1.0,  1.0, 2.0,  2.0]
+    w = [1.0, -1.0, 1.0, -1.0]
+
+    o = WeightedMean()
+    # Weighted mean is empty
+    fit!(o, x[1], w[1])
+    @test mean(o) === 1.0
+    # mean is 1
+    fit!(o, x[2], w[2])
+    @test mean(o) === NaN
+    # mean is NaN because the weight is negative. The negative weight is
+    # "deleting" another weight. So here we should have the same state as a new
+    # WeightedMean() with no data. The mean is undefined.
+    fit!(o, x[3], w[3])
+    @test  mean(o) === 2.0
+    # the mean is 2 because we "deleted" the first value with the second
+    fit!(o, x[4], w[4])
+    @test mean(o) === NaN
+    # the mean is NaN because we "deleted" the third value with the fourth
+
+    o1 = WeightedMean()
+    o2 = WeightedMean()
+
+    fit!(o1, x[1:2], w[1:2])
+    @test mean(o1) === NaN
+    fit!(o2, 1.0, 1.0)
+    @test mean(o2) === 1.0
+    merge!(o1, o2)
+    @test mean(o1) === 1.0
+
+    o1 = WeightedMean()
+    o2 = WeightedMean()
+
+    fit!(o1, x[1:2], w[1:2])
+    @test mean(o1) === NaN
+    fit!(o2, 1.0, 1.0)
+    @test mean(o2) === 1.0
+    merge!(o2, o1)
+    @test mean(o2) === 1.0
+
+end

--- a/test/test_mean.jl
+++ b/test/test_mean.jl
@@ -91,7 +91,7 @@ end
     @test mean(o) === 1.0
     # mean is 1
     fit!(o, x[2], w[2])
-    @test mean(o) === NaN
+    @test isnan(mean(o))
     # mean is NaN because the weight is negative. The negative weight is
     # "deleting" another weight. So here we should have the same state as a new
     # WeightedMean() with no data. The mean is undefined.
@@ -99,14 +99,14 @@ end
     @test  mean(o) === 2.0
     # the mean is 2 because we "deleted" the first value with the second
     fit!(o, x[4], w[4])
-    @test mean(o) === NaN
+    @test isnan(mean(o))
     # the mean is NaN because we "deleted" the third value with the fourth
 
     o1 = WeightedMean()
     o2 = WeightedMean()
 
     fit!(o1, x[1:2], w[1:2])
-    @test mean(o1) === NaN
+    @test isnan(mean(o1))
     fit!(o2, 1.0, 1.0)
     @test mean(o2) === 1.0
     merge!(o1, o2)
@@ -116,7 +116,7 @@ end
     o2 = WeightedMean()
 
     fit!(o1, x[1:2], w[1:2])
-    @test mean(o1) === NaN
+    @test isnan(mean(o1))
     fit!(o2, 1.0, 1.0)
     @test mean(o2) === 1.0
     merge!(o2, o1)


### PR DESCRIPTION
one possible way to address #42 

no idea why
```
@test mean(o1) === NaN
```
is failing when `mean(o1)` evaluates to `NaN`.